### PR TITLE
Include Karpenter-provisioned nodes into consideration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,17 @@ kubectl nodepools list --label 'custom.domain.io/fancy-node-label'
 # list nodes with a nodepool using a custom label
 kubectl nodepools nodes -l 'custom.domain.io/fancy-node-label' $nodepool
 ```
+
+### Working with Karpenter
+Because [Karpenter](https://karpenter.sh/) does not provision node groups, it must be handled separately.
+By default, Karpenter nodes are listed in the format "(Karpenter) {Provisioner}".
+The [Provisioner](https://karpenter.sh/v0.27.1/concepts/provisioners/) refers to the provisioner that Karpenter used to create this particular node.
+In order to search for nodes from particular provisioners, use the `--label` flag.
+
+```shell
+# list nodes with karpenter included
+kubectl nodepools list
+
+# list nodes for a particular karpenter provisioner
+kubectl nodepools list --label 'karpenter.sh/provisioner-name' provisionerA
+```

--- a/main.go
+++ b/main.go
@@ -19,6 +19,11 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
+const (
+	karpenterLabel      string = "karpenter.sh/provisioner-name"
+	karpenterNodeFmtStr string = "(Karpenter) %s"
+)
+
 var (
 	noHeaders bool
 	onlyName  bool
@@ -102,6 +107,12 @@ func findNodepool(node corev1.Node, label string) string {
 	if np, ok := node.Labels[label]; ok {
 		return np
 	}
+
+	// check for karpenter nodes
+	if np, ok := node.Labels[karpenterLabel]; ok {
+		return fmt.Sprintf(karpenterNodeFmtStr, np)
+	}
+
 	for _, lbl := range providerNodepoolLabels {
 		if np, ok := node.Labels[lbl]; ok {
 			return np

--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func listCmd() *cobra.Command {
 				if onlyName {
 					fmt.Fprintln(w, np.Name)
 				} else {
-					typeList := make([]string, len(np.Types))
+					typeList := []string{}
 					for k := range np.Types {
 						typeList = append(typeList, k)
 					}

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func instanceType(node corev1.Node) string {
 
 type nodepool struct {
 	Name  string
-	Type  string
+	Types map[string]bool
 	Nodes uint
 }
 
@@ -166,9 +166,13 @@ func listCmd() *cobra.Command {
 					names = append(names, npName)
 					np = &nodepool{
 						Name: npName,
-						Type: instanceType(n),
+						Types: map[string]bool{
+							instanceType(n): true,
+						},
 					}
 					nps[npName] = np
+				} else {
+					np.Types[instanceType(n)] = true
 				}
 				np.Nodes += 1
 			}
@@ -189,7 +193,13 @@ func listCmd() *cobra.Command {
 				if onlyName {
 					fmt.Fprintln(w, np.Name)
 				} else {
-					fmt.Fprintf(w, "%s\t%5d\t%s\n", np.Name, np.Nodes, np.Type)
+					typeList := make([]string, len(np.Types))
+					i := 0
+					for k := range np.Types {
+						typeList[i] = k
+						i++
+					}
+					fmt.Fprintf(w, "%s\t%5d\t%s\n", np.Name, np.Nodes, strings.Join(typeList, ", "))
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func listCmd() *cobra.Command {
 				if onlyName {
 					fmt.Fprintln(w, np.Name)
 				} else {
-					typeList := []string{}
+					typeList := make([]string, 0, len(np.Types))
 					for k := range np.Types {
 						typeList = append(typeList, k)
 					}

--- a/main.go
+++ b/main.go
@@ -194,11 +194,10 @@ func listCmd() *cobra.Command {
 					fmt.Fprintln(w, np.Name)
 				} else {
 					typeList := make([]string, len(np.Types))
-					i := 0
 					for k := range np.Types {
-						typeList[i] = k
-						i++
+						typeList = append(typeList, k)
 					}
+					sort.Strings(typeList)
 					fmt.Fprintf(w, "%s\t%5d\t%s\n", np.Name, np.Nodes, strings.Join(typeList, ", "))
 				}
 			}


### PR DESCRIPTION
Addresses #3 : Karpenter Support

Karpenter does not provision nodes as part of a node group/pool.  However, they are still useful to see when listing groups or pools of nodes.  This development allows for nodes that have been provisioned by karpenter to be identified by the plugin.

```shell
# list
❯ kubectl nodepools list
NAME                    NODES   TYPE
(Karpenter) default         2   c6a.2xlarge
main-m52xl-2                4   m5.2xlarge

# label search
❯ kubectl nodepools nodes --label 'karpenter.sh/provisioner-name' default
NODE                                            STATUS
ip-10-62-71-26.us-east-2.compute.internal       Ready
ip-10-62-79-122.us-east-2.compute.internal      Ready
```

Note that multiple instance types can be present for a single karpenter provisioner, so output can look like this:

```shell
# list
❯ kubectl nodepools list
NAME                    NODES   TYPE
(Karpenter) default         2   c6a.2xlarge, m5.2xlarge
main-m52xl-2                4   m5.2xlarge
```

This has been achieved by restructuring how the `nodepool` struct is implemented, by having "Types" be a set rather than a single value.