### PR TITLE
Support setting label vale via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ kubectl nodepools nodes $nodepool
 Where `$nodepool` should be the name of an existing node pool.
 
 ### Using a custom node pool label
-If your cluster uses a different label than the ones supported in code, you can pass a custom label using the `--label/-l` flag as in the following examples:
+If your cluster uses a different label than the ones supported in code, you can pass a custom label using the `--label/-l` flag or by setting the `KUBE_NODEPOOLS_LABEL` environment variable:
 
 ```shell
 # list nodepools using a custom label
@@ -45,6 +45,11 @@ kubectl nodepools list --label 'custom.domain.io/fancy-node-label'
 
 # list nodes with a nodepool using a custom label
 kubectl nodepools nodes -l 'custom.domain.io/fancy-node-label' $nodepool
+
+# using environment variable
+export KUBE_NODEPOOLS_LABEL="custom.domain.io/fancy-node-label"
+kubectl nodepools list
+kubectl nodepools nodes $nodepool
 ```
 
 ### Working with Karpenter

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 const (
 	karpenterLabel      string = "karpenter.sh/provisioner-name"
 	karpenterNodeFmtStr string = "(Karpenter) %s"
+
+	customLabelEnvVar = "KUBE_NODEPOOLS_LABEL"
 )
 
 var (
@@ -89,7 +91,8 @@ You can also list nodes for a given node pool/group by name.`,
 	flags := cmd.PersistentFlags()
 	flags.BoolVar(&noHeaders, "no-headers", false, "Don't print headers (default print headers)")
 	flags.StringVarP(&output, "output", "o", "", "Output format. Only name.")
-	flags.StringVarP(&label, "label", "l", "", "Label to group nodes into pools with")
+	labelHelp := fmt.Sprintf("Label to group nodes into pools with; can be set via %s environment variable", customLabelEnvVar)
+	flags.StringVarP(&label, "label", "l", os.Getenv(customLabelEnvVar), labelHelp)
 	kflags.AddFlags(flags)
 
 	return cmd

--- a/main.go
+++ b/main.go
@@ -149,6 +149,8 @@ func listCmd() *cobra.Command {
 		Short: "List node pools/groups in current cluster",
 		Long:  `List node pools/groups in the current cluster, alongside a count of nodes and their type.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			warnEnvLabelUsage(cmd)
+
 			ctx := cmd.Context()
 
 			klient := ctx.Value("klient").(kubernetes.Interface)
@@ -223,6 +225,8 @@ func nodesCmd() *cobra.Command {
 				return errors.New("need to pass a single nodepool name")
 			}
 
+			warnEnvLabelUsage(cmd)
+
 			ctx := cmd.Context()
 
 			klient := ctx.Value("klient").(kubernetes.Interface)
@@ -280,4 +284,10 @@ func nodeCondition(n corev1.Node) string {
 	}
 
 	return s.String()
+}
+
+func warnEnvLabelUsage(cmd *cobra.Command) {
+	if label != "" && !cmd.Parent().PersistentFlags().Changed("label") {
+		fmt.Fprintf(os.Stderr, "Using custom label %q set by environment variable %s\n", label, customLabelEnvVar)
+	}
 }


### PR DESCRIPTION
Use `KUBE_NODEPOOLS_LABEL` environment variable to set the value of the `--label` flag.

In the original issue it was discussed showing a warning message on `stderr` when this flag is set, however, after careful consideration I decided not to include this, as it could be argued the same should be done if `--label` is used.

Closes #9