### PR TITLE
swapping out deprecated flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update new version in krew-index


### PR DESCRIPTION
goreleaser deprecated a flag we were using.  updating

ref: https://goreleaser.com/deprecations/#-rm-dist